### PR TITLE
Align wait-for-it host with libreoffice start command

### DIFF
--- a/rootfs/etc/s6-overlay/s6-rc.d/unoserver-rest-api/run
+++ b/rootfs/etc/s6-overlay/s6-rc.d/unoserver-rest-api/run
@@ -20,7 +20,7 @@ echo
 
 echo "Starting REST API server..."
 set -xe
-wait-for-it --quiet -t 30 "localhost:2002" --strict -- \
+wait-for-it --quiet -t 30 "127.0.0.1:2002" --strict -- \
     unoserver-rest-api \
         --unoconvert-bin "$UNOCONVERT_BIN" \
         --unoconvert-timeout "$UNOCONVERT_TIMEOUT"


### PR DESCRIPTION
libreoffice start command uses the loopback address `127.0.0.1` instead of `localhost`.

This can cause issues in resolving to the correct address if:
- The host machine uses external DNS resolution only and Docker DNS is not explicitly set.
- `/etc/nsswitch.conf` is set to not check local files first.
- The Docker DNS resolution is set for external name resolution only.

This ensures that regardless of DNS resolution issues on the host machine, the container will be able to run, since it doesn't really need these anyway.